### PR TITLE
feature/configure-cors: permitir requisições cross-origin

### DIFF
--- a/src/main/java/com/hackatonone/aprendamais/config/CorsConfig.java
+++ b/src/main/java/com/hackatonone/aprendamais/config/CorsConfig.java
@@ -1,0 +1,26 @@
+package com.hackatonone.aprendamais.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.List;
+
+@Configuration
+public class CorsConfig {
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.setAllowedOrigins(List.of("*"));        // permite qualquer origem
+        configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+        configuration.setAllowedHeaders(List.of("*"));        // permite todos os headers
+        configuration.setAllowCredentials(false);             // necessário se allowedOrigins="*"
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration); // aplica para todos os endpoints
+        return source;
+    }
+}


### PR DESCRIPTION
## Descrição

-   **O que foi feito**
    
    -   Adicionada configuração de CORS (`CorsConfig`) permitindo requisições de qualquer origem.
        
    -   Ajuste no `SecurityConfig` para habilitar CORS globalmente.
        
    -   Teste de endpoint `/me` via `fetch` do navegador com token JWT.
        
-   **Por que foi feito**
    
    -   Antes, requisições do frontend (ou testes com `fetch`) eram bloqueadas por política CORS.
        
    -   Necessário para que frontend e API consigam se comunicar durante desenvolvimento sem erro de bloqueio.
        
-   **Como testar**
    
    -   Rodar `docker compose up --build`.
        
    -   No console do navegador, executar o `fetch` para `http://localhost:8080/me` com o JWT do admin.
        
    -   Verificar se retorna os dados do usuário logado sem erros de CORS.
        
-   **Observações**
    
    -   Esta configuração permite todas as origens (`*`). Para produção, será necessário restringir a origem aos domínios confiáveis do frontend.
        
    -   Branch foi criada a partir da `sprint1` para evitar conflitos e integrar antes de merge.
## Issue relacionada
Conecte com a issue relevante: none

## Checklist
- [x ] Código testado
- [ ] Testes unitários/integração adicionados
- [ ] Documentação atualizada
- [ ] PR revisado por outro dev
- [ ] Merge aprovado pelo menos por 1 revisor

## Labels sugeridos
- backend
- infra
